### PR TITLE
implemented API route to get ticket by id

### DIFF
--- a/app/api/tickets/[ticketId]/route.ts
+++ b/app/api/tickets/[ticketId]/route.ts
@@ -1,0 +1,19 @@
+import { handleApiError } from '@/helpers/errorHandler';
+import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
+
+export const GET = withWorkspaceAuth(async (req, params) => {
+  try {
+    const ticketId = params.ticketId;
+    const ticket = req.workspace.tickets.find(
+      (ticket) => ticket.id === ticketId,
+    );
+
+    if (!ticket) {
+      return Response.json({ error: 'Not found!' }, { status: 404 });
+    }
+
+    return Response.json(ticket, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});


### PR DESCRIPTION
### What this does
Implemented API route to get ticket by id

### Implementation
GET: `/api/tickets/[ticketId]`

returns `Ticket` object or "Not found" if not found in workspace.


