### PR TITLE
implemented services to update ticket status

### DIFF
--- a/app/api/tickets/[ticketId]/route.ts
+++ b/app/api/tickets/[ticketId]/route.ts
@@ -5,6 +5,8 @@ import {
   assginToSchema,
   contactIdSchema,
   prioritySchema,
+  snoozeUntilSchema,
+  statusSchema,
   ticketSourceSchema,
   titleSchema,
 } from '@/lib/zod/ticket';
@@ -34,6 +36,8 @@ const UpdateTicketRequestBody = z.object({
   assignedTo: assginToSchema.optional(),
   priority: prioritySchema.optional(),
   source: ticketSourceSchema.optional(),
+  status: statusSchema.optional(),
+  snoozeUntil: snoozeUntilSchema.optional(),
 });
 
 export const PUT = withWorkspaceAuth(async (req, { ticketId }) => {

--- a/lib/zod/ticket.ts
+++ b/lib/zod/ticket.ts
@@ -1,4 +1,4 @@
-import { PriorityLevels, TicketSource } from '@prisma/client';
+import { PriorityLevels, TicketSource, TicketStatus } from '@prisma/client';
 import { z } from 'zod';
 
 export const titleSchema = z.string({
@@ -27,3 +27,14 @@ export const prioritySchema = z.nativeEnum(PriorityLevels, {
 export const ticketSourceSchema = z.nativeEnum(TicketSource, {
   required_error: "'source' is required!",
 });
+
+export const statusSchema = z.nativeEnum(TicketStatus, {
+  required_error: "'status' is required!",
+});
+
+export const snoozeUntilSchema = z
+  .string({
+    required_error: "'snoozeUntil' is required!",
+    invalid_type_error: "'snoozeUntil' must be of type string!",
+  })
+  .datetime({ message: 'Invalid date string!' });

--- a/prisma/schema/enums.prisma
+++ b/prisma/schema/enums.prisma
@@ -24,3 +24,9 @@ enum TicketSource {
     MAIL
     WEB
 }
+
+enum TicketStatus {
+    OPEN
+    CLOSED
+    SNOOZE
+}

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -65,6 +65,8 @@ model Ticket {
   source        TicketSource
   mail_id       String         @unique
   labels        TicketLabel[]
+  status        TicketStatus   @default(OPEN)
+  snooze_until  DateTime?
 }
 
 model Message {

--- a/services/serverSide/ticket.ts
+++ b/services/serverSide/ticket.ts
@@ -1,4 +1,9 @@
-import { PriorityLevels, Prisma, TicketSource } from '@prisma/client';
+import {
+  PriorityLevels,
+  Prisma,
+  TicketSource,
+  TicketStatus,
+} from '@prisma/client';
 import { createOrUpdateContact } from './contact';
 import { prisma } from '@/prisma/prisma';
 import { removeNullUndefined } from '@/helpers/common';
@@ -83,13 +88,28 @@ export const updateTicket = async (
     source?: TicketSource;
     contanctId?: string;
     assignedTo?: string;
+    status?: TicketStatus;
+    snoozeUntil?: string;
   },
 ) => {
-  removeNullUndefined(ticketUpdates);
+  const update: any = {
+    title: ticketUpdates.title,
+    priority: ticketUpdates.priority,
+    source: ticketUpdates.source,
+    contact_id: ticketUpdates.contanctId,
+    assigned_to: ticketUpdates.assignedTo,
+    status: ticketUpdates.status,
+  };
+
+  if (ticketUpdates.snoozeUntil) {
+    update.snooze_until = ticketUpdates.snoozeUntil;
+  }
+
+  removeNullUndefined(update);
 
   const newTicket = await prisma.ticket.update({
     where: { id: ticketId },
-    data: ticketUpdates,
+    data: update,
   });
 
   return newTicket;


### PR DESCRIPTION
### What this does
Implemented services to update ticket's status (Open, Closed, Snooze).

### Implementation
Added 2 extra fields in Ticket's schema `status` and `snooze_until` to managed statues of the tickets.
These fields can be changed by ticket's update API.


