### PR TITLE
Origin/setting/member/show admin owner tag based on user role

### DIFF
--- a/app/setting/members/page.tsx
+++ b/app/setting/members/page.tsx
@@ -65,7 +65,7 @@ const Members = () => {
                   name={member.display_name || ''}
                   email={member.email}
                   src={member.profile_url || ''}
-                  designation={member.role}
+                  designation={member.role !== 'MEMBER' ? member.role : ''}
                 />
               ))}
             </MainCardDiv>

--- a/app/setting/members/page.tsx
+++ b/app/setting/members/page.tsx
@@ -65,7 +65,7 @@ const Members = () => {
                   name={member.display_name || ''}
                   email={member.email}
                   src={member.profile_url || ''}
-                  designation={''}
+                  designation={member.role}
                 />
               ))}
             </MainCardDiv>


### PR DESCRIPTION
### What this does
Setting - member - show Admin/Owner tag based on user's role

### Implementation
show Admin/Owner tag based on user's role

### Testing
![image](https://github.com/user-attachments/assets/efba3148-87fc-4a01-885f-00f43cfe1125)

