### PR TITLE
Implement services and api route to create and fetch api keys

### DIFF
--- a/app/api/workspaces/apikeys/route.ts
+++ b/app/api/workspaces/apikeys/route.ts
@@ -1,0 +1,29 @@
+import { handleApiError } from '@/helpers/errorHandler';
+import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
+import {
+  createApiKey,
+  getWorkspaceApiKeys,
+} from '@/services/serverSide/apiKey';
+
+export const GET = withWorkspaceAuth(async (req) => {
+  try {
+    const apiKeys = await getWorkspaceApiKeys(req.workspace.id);
+
+    return Response.json(apiKeys, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});
+
+export const POST = withWorkspaceAuth(async (req) => {
+  try {
+    const userId = req.user.id;
+    const workspaceId = req.workspace.id;
+
+    const apiKey = await createApiKey({ userId, workspaceId });
+
+    return Response.json(apiKey, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});

--- a/helpers/common.tsx
+++ b/helpers/common.tsx
@@ -142,3 +142,22 @@ export const getFirebaseUrlFromFile = async (file: any, folderName: string) => {
     alert(`Getting error for upload file ${e}`);
   }
 };
+
+export const generateApiKey = () => {
+  const alphabets = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const apiKeyParts: string[] = [];
+
+  for (let i = 0; i < 4; i++) {
+    let apiKeyPart = '';
+
+    for (let j = 0; j < 5; j++) {
+      const randomIndex = Math.floor(Math.random() * alphabets.length);
+      apiKeyPart += alphabets[randomIndex];
+    }
+
+    apiKeyParts.push(apiKeyPart);
+  }
+  const apiKey = apiKeyParts.join('-');
+
+  return apiKey;
+};

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -21,6 +21,7 @@ model User {
   messages      Message[]
   tickets       Ticket[]
   workspaces    UserWorkspaces[]
+  api_keys      ApiKeys[]
 }
 
 model Workspace {
@@ -35,6 +36,7 @@ model Workspace {
   tickets       Ticket[]
   users         UserWorkspaces[]
   ticketLabels  Label[]
+  api_keys      ApiKeys[]
 }
 
 model Label {
@@ -114,4 +116,13 @@ model InvitedUser {
   created_at      DateTime  @default(now())
   invited_by_user User      @relation(fields: [invited_by], references: [id])
   workspace       Workspace @relation(fields: [workspace_id], references: [id])
+}
+
+model ApiKeys {
+  api_key      String    @id
+  workspace_id String
+  created_by   String
+  created_at   DateTime  @default(now())
+  workspace    Workspace @relation(fields: [workspace_id], references: [id])
+  user         User      @relation(fields: [created_by], references: [id])
 }

--- a/services/serverSide/apiKey.ts
+++ b/services/serverSide/apiKey.ts
@@ -1,0 +1,26 @@
+import { generateApiKey } from '@/helpers/common';
+import { prisma } from '@/prisma/prisma';
+
+export const getWorkspaceApiKeys = async (workspaceId: string) => {
+  const apiKeys = await prisma.apiKeys.findMany({
+    where: { workspace_id: workspaceId },
+  });
+
+  return apiKeys;
+};
+
+export const createApiKey = async ({
+  userId,
+  workspaceId,
+}: {
+  userId: string;
+  workspaceId: string;
+}) => {
+  const api_key = generateApiKey();
+
+  const apiKey = await prisma.apiKeys.create({
+    data: { api_key, created_by: userId, workspace_id: workspaceId },
+  });
+
+  return apiKey;
+};


### PR DESCRIPTION
### What this does
Implemented services and API route to create and fetch API keys.

### Implementation
POST: `/api/workspaces/apikeys`
Returns generated API key.

GET: `/api/workspaces/apikeys`
Return list of api keys of a workspace.
