### PR TITLE
implement service and API route to get workspace labels

### DIFF
--- a/app/api/workspaces/labels/route.ts
+++ b/app/api/workspaces/labels/route.ts
@@ -3,7 +3,18 @@ import { handleApiError } from '@/helpers/errorHandler';
 import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
 import { nameSchema } from '@/lib/zod/common';
 import { colorSchema, iconSchema } from '@/lib/zod/label';
-import { createLabel } from '@/services/serverSide/label';
+import { createLabel, getWorkspaceLabels } from '@/services/serverSide/label';
+
+export const GET = withWorkspaceAuth(async (req) => {
+  try {
+    const workspaceId = req.workspace.id;
+    const labels = await getWorkspaceLabels(workspaceId);
+
+    return Response.json(labels, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});
 
 const RequestBody = z.object({
   name: nameSchema,

--- a/services/serverSide/label.ts
+++ b/services/serverSide/label.ts
@@ -11,6 +11,14 @@ export const getTicketLabels = async (ticketId: string) => {
   return formattedLabels;
 };
 
+export const getWorkspaceLabels = async (workspaceId: string) => {
+  const labels = await prisma.label.findMany({
+    where: { workspace_id: workspaceId },
+  });
+
+  return labels;
+};
+
 export const createLabel = async ({
   name,
   icon,


### PR DESCRIPTION
### What this does
Implement service and API route to get workspace labels.

### Implementation
GET: `/api/workspaces/labels`
Return list of workspace labels

