### PR TITLE
Implement name field in api keys

### DIFF
--- a/app/api/workspaces/apikeys/route.ts
+++ b/app/api/workspaces/apikeys/route.ts
@@ -1,4 +1,5 @@
 import { handleApiError } from '@/helpers/errorHandler';
+import { nameSchema } from '@/lib/zod/common';
 import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
 import {
   createApiKey,
@@ -17,10 +18,14 @@ export const GET = withWorkspaceAuth(async (req) => {
 
 export const POST = withWorkspaceAuth(async (req) => {
   try {
+    const { name } = await req.json();
+
+    nameSchema.parse(name);
+
     const userId = req.user.id;
     const workspaceId = req.workspace.id;
 
-    const apiKey = await createApiKey({ userId, workspaceId });
+    const apiKey = await createApiKey({ userId, workspaceId, name });
 
     return Response.json(apiKey, { status: 201 });
   } catch (err) {

--- a/app/api/workspaces/labels/route.ts
+++ b/app/api/workspaces/labels/route.ts
@@ -3,7 +3,18 @@ import { handleApiError } from '@/helpers/errorHandler';
 import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
 import { nameSchema } from '@/lib/zod/common';
 import { colorSchema, iconSchema } from '@/lib/zod/label';
-import { createLabel } from '@/services/serverSide/label';
+import { createLabel, getWorkspaceLabels } from '@/services/serverSide/label';
+
+export const GET = withWorkspaceAuth(async (req) => {
+  try {
+    const workspaceId = req.workspace.id;
+    const labels = await getWorkspaceLabels(workspaceId);
+
+    return Response.json(labels, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});
 
 const RequestBody = z.object({
   name: nameSchema,

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -120,6 +120,7 @@ model InvitedUser {
 
 model ApiKeys {
   api_key      String    @id
+  name         String
   workspace_id String
   created_by   String
   created_at   DateTime  @default(now())

--- a/services/serverSide/apiKey.ts
+++ b/services/serverSide/apiKey.ts
@@ -12,14 +12,16 @@ export const getWorkspaceApiKeys = async (workspaceId: string) => {
 export const createApiKey = async ({
   userId,
   workspaceId,
+  name,
 }: {
   userId: string;
   workspaceId: string;
+  name: string;
 }) => {
   const api_key = generateApiKey();
 
   const apiKey = await prisma.apiKeys.create({
-    data: { api_key, created_by: userId, workspace_id: workspaceId },
+    data: { api_key, created_by: userId, workspace_id: workspaceId, name },
   });
 
   return apiKey;

--- a/services/serverSide/label.ts
+++ b/services/serverSide/label.ts
@@ -11,6 +11,14 @@ export const getTicketLabels = async (ticketId: string) => {
   return formattedLabels;
 };
 
+export const getWorkspaceLabels = async (workspaceId: string) => {
+  const labels = await prisma.label.findMany({
+    where: { workspace_id: workspaceId },
+  });
+
+  return labels;
+};
+
 export const createLabel = async ({
   name,
   icon,


### PR DESCRIPTION
### What this does
Implemented `name` field in API keys.

### Implementation
POST: `/api/workspaces/apiKeys`
```json
{
"name": "Name of the API key"
}
```
