### PR TITLE
implemented snooze until field for status Snooze

### DIFF
--- a/app/api/tickets/[ticketId]/changeStatus/route.ts
+++ b/app/api/tickets/[ticketId]/changeStatus/route.ts
@@ -1,6 +1,6 @@
-import { MessageType } from '@prisma/client';
+import { MessageType, TicketStatus } from '@prisma/client';
 import { handleApiError } from '@/helpers/errorHandler';
-import { statusSchema } from '@/lib/zod/ticket';
+import { snoozeUntilSchema, statusSchema } from '@/lib/zod/ticket';
 import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
 import { postMessage } from '@/services/serverSide/message';
 import { updateStatus } from '@/services/serverSide/ticket';
@@ -8,9 +8,13 @@ import { updateStatus } from '@/services/serverSide/ticket';
 // PUT: /api/tickets/[ticketId]/changeStatus
 export const PUT = withWorkspaceAuth(async (req, { ticketId }) => {
   try {
-    const { status } = await req.json();
+    const { status, snoozeUntil } = await req.json();
 
     statusSchema.parse(status);
+
+    if (status === TicketStatus.SNOOZE) {
+      snoozeUntilSchema.parse(snoozeUntil);
+    }
 
     const updatedTicket = await updateStatus(ticketId, status);
 

--- a/services/serverSide/ticket.ts
+++ b/services/serverSide/ticket.ts
@@ -176,11 +176,24 @@ export const updatePriority = async (
 export const updateStatus = async (
   ticketId: string,
   newStatus: TicketStatus,
+  snoozeUntil?: string,
 ) => {
+  if (newStatus === TicketStatus.SNOOZE && !snoozeUntil) {
+    throw new Error('snoozeUntil is required for status type SNOOZE');
+  }
+
+  const payload = {
+    status: newStatus,
+    snoozeUntil: snoozeUntil,
+  };
+
+  removeNullUndefined(payload);
+
   const updatedTicket = await prisma.ticket.update({
     where: { id: ticketId },
-    data: { status: newStatus },
+    data: payload,
   });
+
   return updatedTicket;
 };
 


### PR DESCRIPTION
### What this does
Implemented snooze until field for ticket status SNOOZE

### Implementation
PUT: `/api/tickets/{ticketId}`
```json
{
"status": "SNOOZE"
"snoozeUntil": "datetime"
}
```

