### PR TITLE
fixed refrenceId typo

### DIFF
--- a/app/api/tickets/[ticketId]/changeAssignee/route.ts
+++ b/app/api/tickets/[ticketId]/changeAssignee/route.ts
@@ -17,7 +17,7 @@ export const PUT = withWorkspaceAuth(async (req, { ticketId }) => {
     const userId = req.user.id;
     await postMessage({
       messageContent: '',
-      referenceId: assignee,
+      referenceId: assignee || req.user.id,
       messageType: MessageType.CHANGE_ASSIGNEE,
       ticketId,
       authorId: userId,


### PR DESCRIPTION
### What this does
When someone unassign all users then their user ID is stored in message refrence id.
