### PR TITLE
implemented last seen for ticket and messages

### DIFF
--- a/app/api/tickets/[ticketId]/messages/route.ts
+++ b/app/api/tickets/[ticketId]/messages/route.ts
@@ -6,6 +6,7 @@ import {
   createEmailEvent,
   getTicketMessages,
   postMessage,
+  updateUserLastSeen,
 } from '@/services/serverSide/message';
 import { contentSchema, messageTypeSchema } from '@/lib/zod/message';
 import { sendEmailAsReply } from '@/helpers/emails';
@@ -13,6 +14,8 @@ import { getWorkspaceEmailConfig } from '@/services/serverSide/workspace';
 
 export const GET = withWorkspaceAuth(async (req, { ticketId }) => {
   try {
+    await updateUserLastSeen(ticketId, req.user.id);
+
     const messages = await getTicketMessages(ticketId);
 
     return Response.json(messages, { status: 200 });

--- a/app/api/tickets/route.ts
+++ b/app/api/tickets/route.ts
@@ -11,7 +11,11 @@ export const GET = withWorkspaceAuth(async (req) => {
 
     lastUpdatedTimeSchema.optional().parse(lastUpdated);
 
-    const tickets = await getWorkspaceTickets(workspaceId, lastUpdated);
+    const tickets = await getWorkspaceTickets(
+      workspaceId,
+      req.user.id,
+      lastUpdated,
+    );
 
     return Response.json(tickets, { status: 200 });
   } catch (err) {

--- a/app/details/[ticket_id]/ticketDetails.tsx
+++ b/app/details/[ticket_id]/ticketDetails.tsx
@@ -324,7 +324,7 @@ function TicketDetails(props: Props) {
         type = MessageType.EMAIL;
       }
       const payload = { content: content, type };
-      const newMessage: MessageDetails = {
+      const newMessage = {
         assignee: null,
         author: user,
         author_id: user!.id,
@@ -335,7 +335,8 @@ function TicketDetails(props: Props) {
         reference_id: '',
         ticket_id,
         type,
-      };
+        // add default ready_by field
+      } as MessageDetails;
 
       try {
         if (ticket_id) {

--- a/prisma/schema/enums.prisma
+++ b/prisma/schema/enums.prisma
@@ -1,53 +1,53 @@
 enum TeamSize {
-    SMALL
-    MEDIUM
-    LARGE
-    ENTERPRISE
+  SMALL
+  MEDIUM
+  LARGE
+  ENTERPRISE
 }
 
 enum PriorityLevels {
-    NONE
-    LOW
-    MEDIUM
-    HIGH
-    URGENT
+  NONE
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
 }
 
 enum MessageType {
-    REGULAR
-    EMAIL
-    CHANGE_PRIORITY
-    CHANGE_ASSIGNEE
-    CHANGE_LABEL
-    CHANGE_STATUS
-    FROM_CONTACT
+  REGULAR
+  EMAIL
+  CHANGE_PRIORITY
+  CHANGE_ASSIGNEE
+  CHANGE_LABEL
+  CHANGE_STATUS
+  FROM_CONTACT
 }
 
 enum TicketSource {
-    MAIL
-    WEB
+  MAIL
+  WEB
 }
 
 enum TicketStatus {
-    OPEN
-    CLOSED
+  OPEN
+  CLOSED
 }
 
 enum UserRole {
-    MEMBER
-    ADMIN
-    OWNER
+  MEMBER
+  ADMIN
+  OWNER
 }
 
 enum ConfigType {
-    CHANNEL
+  CHANNEL
 }
 
 enum EmailEventType {
-    OPENED
-    BOUNCED
-    DELIVERED
-    LINK_CLICKED
-    SPAMED
-    FAILED
+  OPENED
+  BOUNCED
+  DELIVERED
+  LINK_CLICKED
+  SPAMED
+  FAILED
 }

--- a/prisma/schema/relations.prisma
+++ b/prisma/schema/relations.prisma
@@ -17,3 +17,15 @@ model TicketLabel {
 
     @@id(name: "ticket_label_id", [label_id, ticket_id])
 }
+
+model TicketUser {
+    ticket_id String
+    user_id   String
+
+    user   User   @relation(fields: [user_id], references: [id])
+    ticket Ticket @relation(fields: [ticket_id], references: [id])
+
+    last_seen DateTime @default(now())
+
+    @@id(name: "ticket_user_id", [ticket_id, user_id])
+}

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -23,6 +23,7 @@ model User {
   workspaces    UserWorkspaces[]
   api_keys      ApiKeys[]
   macros        Macro[]
+  tickets_rel   TicketUser[]
 }
 
 model Workspace {
@@ -74,6 +75,7 @@ model Ticket {
   labels        TicketLabel[]
   status        TicketStatus   @default(OPEN)
   snooze_until  DateTime?
+  users         TicketUser[]
 }
 
 model Message {

--- a/services/serverSide/ticket.ts
+++ b/services/serverSide/ticket.ts
@@ -19,6 +19,7 @@ type TicketWithPayload = Prisma.TicketGetPayload<{
 
 export const getWorkspaceTickets = async (
   workspaceId: string,
+  userId: string,
   lastUpdated?: string,
 ) => {
   const query: Prisma.TicketWhereInput = { workspace_id: workspaceId };
@@ -58,9 +59,30 @@ export const getWorkspaceTickets = async (
     },
   });
 
+  const ticketIds = tickets.map((t) => t.id);
+
+  const ticketLastSeen = await prisma.ticketUser.findMany({
+    where: { ticket_id: { in: ticketIds }, user_id: userId },
+    select: { last_seen: true, ticket_id: true },
+  });
+
+  const ticketLastSeenMap = new Map<string, Date>();
+  ticketLastSeen.forEach((t) =>
+    ticketLastSeenMap.set(t.ticket_id, new Date(t.last_seen)),
+  );
+
   const ticketsWithLastMessage = tickets.map((ticket) => {
     const { messages, ...rest } = ticket;
-    const newTicket = { ...rest, last_message: messages[0] };
+    const last_message = messages[0];
+
+    let has_read = false;
+    if (ticketLastSeenMap.has(ticket.id)) {
+      has_read =
+        ticketLastSeenMap.get(ticket.id)!.getTime() >=
+        new Date(last_message.created_at).getTime();
+    }
+
+    const newTicket = { ...rest, last_message, has_read };
 
     return newTicket;
   });


### PR DESCRIPTION
### What this does
Implemeted `has_read` field for workspace tickets list and `ready_by` for individual messages of a ticket.

### Implementation
If the created time of ticket's last message is greater than user's last seen than ticket is new and has not read.
added list of users in `read_by` field in message object, which shows which users has read that message.


