### PR TITLE
display showDotIcon based on has_read

### DIFF
--- a/app/inbox/inbox.tsx
+++ b/app/inbox/inbox.tsx
@@ -135,7 +135,7 @@ function Inbox({ activeNav, labelId }: InboxProps) {
                       <InboxCard
                         ticketDetail={ticket}
                         description={ticket.last_message?.content || ''}
-                        showDotIcon={true}
+                        showDotIcon={!ticket?.has_read}
                         src=''
                         currentOpenDropdown={currentOpenDropdown}
                         setCurrentOpenDropdown={setCurrentOpenDropdown}

--- a/components/inboxCard/inboxCard.tsx
+++ b/components/inboxCard/inboxCard.tsx
@@ -54,7 +54,7 @@ interface Props {
 const InboxCard = ({
   ticketDetail,
   description,
-  showDotIcon = false,
+  showDotIcon,
   src,
   currentOpenDropdown,
   setCurrentOpenDropdown,

--- a/utils/appTypes.tsx
+++ b/utils/appTypes.tsx
@@ -20,6 +20,7 @@ export type TicketDetailsInterface = NonNullable<
   Awaited<ReturnType<typeof formatTicket>>
 > & {
   last_message?: LastMessage; // Make the last_message field optional
+  has_read: boolean;
 };
 
 interface LastMessage {


### PR DESCRIPTION
### What this does
Tickets - show this read icon dynamic based on has_read

### Implementation
display showDotIcon based on has_read

### Testing
![image](https://github.com/user-attachments/assets/521e07da-ca33-4185-8465-17b02b090d57)
