### PR TITLE
Implement service to upload attachment while sending

### DIFF
--- a/app/api/webhooks/postmark/route.ts
+++ b/app/api/webhooks/postmark/route.ts
@@ -58,6 +58,7 @@ export const POST = async (req: NextRequest) => {
       });
 
       await uploadAttachments(
+        workspaceId,
         ticket.id,
         message.id,
         postmarkPayload.Attachments,

--- a/lib/zod/message.ts
+++ b/lib/zod/message.ts
@@ -10,3 +10,8 @@ export const messageTypeSchema = z.enum(
   [MessageType.REGULAR, MessageType.EMAIL],
   { required_error: "'type' is required!" },
 );
+
+export const attachmentTokenSchema = z.string({
+  required_error: "'attachmentToken' is required!",
+  invalid_type_error: "'attachmentToken' must be of type string!",
+});


### PR DESCRIPTION
### What this does
Implemented services to upload attachments while sending attachments.

### Implementation
The client uploads the attachements client and share an `attachmentToken` which transfers the attached files to newly created message.

### Testing
![image](https://github.com/user-attachments/assets/1f3a6646-555b-4d77-aa7c-c0c054237621)
