### PR TITLE
Bugfix/display macros based on user role

### DIFF
--- a/app/details/[ticket_id]/ticketDetails.tsx
+++ b/app/details/[ticket_id]/ticketDetails.tsx
@@ -707,19 +707,18 @@ function TicketDetails(props: Props) {
                         })(),
                       }}
                     />
-                    {macros.length > 0 && (
+                    {(macros.length > 0 ||
+                      currentWorkspace?.role === UserRole.OWNER ||
+                      currentWorkspace?.role === UserRole.ADMIN) && (
                       <div className='tag-div'>
-                        {(currentWorkspace?.role === UserRole.OWNER ||
-                          currentWorkspace?.role === UserRole.ADMIN) && (
-                          <Icon
-                            iconName='sticky-note-icon'
-                            iconSize='12'
-                            iconViewBox='0 0 12 12'
-                            size={true}
-                            onClick={handleMacroItem}
-                            isActive={true}
-                          />
-                        )}
+                        <Icon
+                          iconName='sticky-note-icon'
+                          iconSize='12'
+                          iconViewBox='0 0 12 12'
+                          size={true}
+                          onClick={handleMacroItem}
+                          isActive={true}
+                        />
                         {macroDropdown && (
                           <DropDown
                             items={macros}
@@ -728,7 +727,11 @@ function TicketDetails(props: Props) {
                             onChange={handleMacroSelect}
                             iconSize={''}
                             iconViewBox={''}
-                            style={{ bottom: 60, maxWidth: 146, width: '100%' }}
+                            style={{
+                              bottom: 60,
+                              maxWidth: 146,
+                              width: '100%',
+                            }}
                             isMacro={
                               currentWorkspace?.role === UserRole.OWNER ||
                               currentWorkspace?.role === UserRole.ADMIN

--- a/app/details/[ticket_id]/ticketDetails.tsx
+++ b/app/details/[ticket_id]/ticketDetails.tsx
@@ -707,31 +707,36 @@ function TicketDetails(props: Props) {
                         })(),
                       }}
                     />
-                    <div className='tag-div'>
-                      <Icon
-                        iconName='sticky-note-icon'
-                        iconSize='12'
-                        iconViewBox='0 0 12 12'
-                        size={true}
-                        onClick={handleMacroItem}
-                        isActive={true}
-                      />
-                      {macroDropdown && (
-                        <DropDown
-                          items={macros}
-                          labelField='title'
-                          onClose={handleOutsideClick}
-                          onChange={handleMacroSelect}
-                          iconSize={''}
-                          iconViewBox={''}
-                          style={{ bottom: 60, maxWidth: 146, width: '100%' }}
-                          isMacro={
-                            currentWorkspace?.role === UserRole.OWNER ||
-                            currentWorkspace?.role === UserRole.ADMIN
-                          }
-                        />
-                      )}
-                    </div>
+                    {macros.length > 0 && (
+                      <div className='tag-div'>
+                        {currentWorkspace?.role === UserRole.OWNER ||
+                          (currentWorkspace?.role === UserRole.ADMIN && (
+                            <Icon
+                              iconName='sticky-note-icon'
+                              iconSize='12'
+                              iconViewBox='0 0 12 12'
+                              size={true}
+                              onClick={handleMacroItem}
+                              isActive={true}
+                            />
+                          ))}
+                        {macroDropdown && (
+                          <DropDown
+                            items={macros}
+                            labelField='title'
+                            onClose={handleOutsideClick}
+                            onChange={handleMacroSelect}
+                            iconSize={''}
+                            iconViewBox={''}
+                            style={{ bottom: 60, maxWidth: 146, width: '100%' }}
+                            isMacro={
+                              currentWorkspace?.role === UserRole.OWNER ||
+                              currentWorkspace?.role === UserRole.ADMIN
+                            }
+                          />
+                        )}
+                      </div>
+                    )}
                   </div>
                   <IconDiv modeSelectedItem={modeSelectedItem}>
                     <Icon

--- a/app/details/[ticket_id]/ticketDetails.tsx
+++ b/app/details/[ticket_id]/ticketDetails.tsx
@@ -709,17 +709,17 @@ function TicketDetails(props: Props) {
                     />
                     {macros.length > 0 && (
                       <div className='tag-div'>
-                        {currentWorkspace?.role === UserRole.OWNER ||
-                          (currentWorkspace?.role === UserRole.ADMIN && (
-                            <Icon
-                              iconName='sticky-note-icon'
-                              iconSize='12'
-                              iconViewBox='0 0 12 12'
-                              size={true}
-                              onClick={handleMacroItem}
-                              isActive={true}
-                            />
-                          ))}
+                        {(currentWorkspace?.role === UserRole.OWNER ||
+                          currentWorkspace?.role === UserRole.ADMIN) && (
+                          <Icon
+                            iconName='sticky-note-icon'
+                            iconSize='12'
+                            iconViewBox='0 0 12 12'
+                            size={true}
+                            onClick={handleMacroItem}
+                            isActive={true}
+                          />
+                        )}
                         {macroDropdown && (
                           <DropDown
                             items={macros}


### PR DESCRIPTION
### What this does
Ticket details - when macros list is empty and user is not admin/owner hide this

### Implementation
display macros based on user role

### Testing
Member:
![image](https://github.com/user-attachments/assets/1841a20c-1a04-41ca-bc62-184ec3052682)
Admin/Owner
![image](https://github.com/user-attachments/assets/df6210f6-38e0-4146-bc38-4b329b0e0e69)

