### PR TITLE
implement attachment field in create ticket

### DIFF
--- a/app/api/tickets/[ticketId]/changeAssignee/route.ts
+++ b/app/api/tickets/[ticketId]/changeAssignee/route.ts
@@ -3,9 +3,8 @@ import { handleApiError } from '@/helpers/errorHandler';
 import { assignToSchema } from '@/lib/zod/ticket';
 import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
 import { postMessage } from '@/services/serverSide/message';
-import { getTicketById, updateAssignee } from '@/services/serverSide/ticket';
+import { updateAssignee } from '@/services/serverSide/ticket';
 import { NotificationProvider } from '@/services/serverSide/notifications';
-import { getUserById } from '@/services/serverSide/user';
 
 // PUT: /api/tickets/[ticketId]/changeAssignee
 export const PUT = withWorkspaceAuth(async (req, { ticketId }) => {

--- a/helpers/common.tsx
+++ b/helpers/common.tsx
@@ -6,6 +6,7 @@ import {
   uploadBytesResumable,
 } from 'firebase/storage';
 import { convert } from 'html-to-text';
+import axios from 'axios';
 import { app } from '@/utils/firebase';
 import { workspaceStore } from '@/stores/workspaceStore';
 import { messageStore } from '@/stores/messageStore';
@@ -228,4 +229,25 @@ export const htmlToString = (html: string) => {
   const plainText = convert(html, { wordwrap: 130 });
 
   return plainText;
+};
+
+/**
+ * Downloads a file from the given URL and converts it to a Base64 string.
+ *
+ * @param fileUrl - The URL of the file to download.
+ * @returns A promise that resolves to the Base64 string of the downloaded file.
+ */
+export const downloadFileAsBase64 = async (fileUrl: string) => {
+  const response = await axios.get(fileUrl, {
+    responseType: 'arraybuffer', // Ensures response is returned as a Buffer
+  });
+
+  // Convert the response data (buffer) to a Base64 string
+  const base64String = Buffer.from(response.data, 'binary').toString('base64');
+
+  // Optionally, you can add a MIME type prefix to the base64 string for some use cases
+  const mimeType = response.headers['content-type'];
+  // return `data:${mimeType};base64,${base64String}`;
+
+  return { contentType: mimeType, content: base64String };
 };

--- a/lib/zod/message.ts
+++ b/lib/zod/message.ts
@@ -15,3 +15,16 @@ export const attachmentTokenSchema = z.string({
   required_error: "'attachmentToken' is required!",
   invalid_type_error: "'attachmentToken' must be of type string!",
 });
+
+export const attachmentSchema = z.object({
+  filename: z.string({
+    required_error: "'filename' is required!",
+    invalid_type_error: "'filename' must be of type string!",
+  }),
+  url: z
+    .string({
+      required_error: "'url' is required!",
+      invalid_type_error: "'url' must be of type string!",
+    })
+    .url(),
+});


### PR DESCRIPTION
### What this does
Implemented `attachment` field in create ticket API.

### Implementation
POST: `/api/tickets`
```json
{
    "senderName": "Vatsal",
    "senderEmail": "vatsal.ghoghari@pixer.digital",
    "message": "Web ticket with attachments test",
    "attachments": [
        {
            "filename": "apple.png",
            "url": "https://firebasestorage.googleapis.com/v0/b/learning-a689b.appspot.com/o/images%2Fapple.png?alt=media"
        }
    ]
}
```

### Testing
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/4bcaf093-3ac4-490e-9e2a-edbd34d441f9">
