### PR TITLE
implemented API route to create and update groups

### DIFF
--- a/app/api/groups/[groupId]/route.ts
+++ b/app/api/groups/[groupId]/route.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { handleApiError } from '@/helpers/errorHandler';
+import { nameSchema } from '@/lib/zod/common';
+import { groupLabelSchema } from '@/lib/zod/group';
+import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
+import { customTraitsSchema } from '@/lib/zod/contact';
+import { updateGroup } from '@/services/serverSide/group';
+
+const UpdateGroupBody = z.object({
+  name: nameSchema.optional(),
+  groupLabel: groupLabelSchema.optional(),
+  customTraits: customTraitsSchema.optional(),
+});
+export const PUT = withWorkspaceAuth(async (req, { groupId }) => {
+  try {
+    const requestBody = await req.json();
+
+    UpdateGroupBody.parse(requestBody);
+
+    const groupData = requestBody as z.infer<typeof UpdateGroupBody>;
+    const updatedGroup = await updateGroup(groupId, groupData);
+
+    return Response.json(updatedGroup, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { handleApiError } from '@/helpers/errorHandler';
+import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
+import { createGroup, getWorkspaceGroups } from '@/services/serverSide/group';
+import { nameSchema } from '@/lib/zod/common';
+import { groupLabelSchema } from '@/lib/zod/group';
+import { customTraitsSchema } from '@/lib/zod/contact';
+
+export const GET = withWorkspaceAuth(async (req) => {
+  try {
+    const groups = await getWorkspaceGroups(req.workspace.id);
+
+    return Response.json(groups, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});
+
+const CreateGroupBody = z.object({
+  name: nameSchema,
+  groupLabel: groupLabelSchema,
+  customTraits: customTraitsSchema.optional(),
+});
+export const POST = withWorkspaceAuth(async (req) => {
+  try {
+    const requestBody = await req.json();
+
+    CreateGroupBody.parse(requestBody);
+
+    const { name, groupLabel } = requestBody as z.infer<typeof CreateGroupBody>;
+
+    const newGroup = await createGroup(req.workspace.id, { name, groupLabel });
+
+    return Response.json(newGroup, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});


### PR DESCRIPTION
### What this does
Implemented API routes to create and update groups.

### Implementation
GET: `/api/groups`
Returns array of workspace's groups

POST: `/api/groups`
This API creates a group on workspace
```json
{
  "name": "Engineering Team",
  "groupLabel": "Development",
  "customTraits": {
    "project": "Teamcamp",
    "location": "Remote"
  }
}
```

PUT: `/api/groups/{groupId}`
This API updates group on workspace
```json
{
  "name": "Engineering Team",
  "groupLabel": "Development",
  "customTraits": {
    "project": "Teamcamp",
    "location": "Remote"
  }
}
```
