### PR TITLE
implemented API route to get contacts groups

### DIFF
--- a/app/api/contacts/[contactId]/groups/route.ts
+++ b/app/api/contacts/[contactId]/groups/route.ts
@@ -1,0 +1,13 @@
+import { handleApiError } from '@/helpers/errorHandler';
+import withWorkspaceAuth from '@/middlewares/withWorkspaceAuth';
+import { getContactGroups } from '@/services/serverSide/contact';
+
+export const GET = withWorkspaceAuth(async (req, { contactId }) => {
+  try {
+    const groups = await getContactGroups(contactId);
+
+    return Response.json(groups, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+});

--- a/services/serverSide/contact.ts
+++ b/services/serverSide/contact.ts
@@ -146,3 +146,16 @@ export const getActivities = async (email: string) => {
 
   return formattedEventsData;
 };
+
+export const getContactGroups = async (contactId: string) => {
+  const contactGroups = await prisma.contactGroup.findMany({
+    where: { contact_id: contactId },
+    select: {
+      group: true,
+    },
+  });
+
+  const groups = contactGroups.map((cg) => cg.group);
+
+  return groups;
+};


### PR DESCRIPTION
### What this does
Implemented API route to get Contact's groups.

### Implementation
GET: `/api/contacts/{contactId}/groups`
Returns groups info for a contact

