### PR TITLE
bugfix/auth/send verification code/fix otp length and max length 5

### DIFF
--- a/helpers/common.tsx
+++ b/helpers/common.tsx
@@ -82,7 +82,7 @@ export const formatTime = (isoString: string) => {
 export const generateVerificationCode = (length = 5) => {
   let code = '';
   while (code.length < length) {
-    const randomNum = Math.ceil(Math.random() * 10);
+    const randomNum = Math.floor(Math.random() * 10);
     code += `${randomNum}`;
   }
   return code;


### PR DESCRIPTION
### What this does
bugfix/auth/send verification code/fix otp length and max length 5

### Implementation
bugfix/auth/send verification code/fix otp length and max length 5

### Testing
![image](https://github.com/user-attachments/assets/7f55d8be-5d3b-4805-bff4-4092aa077da7)
![image](https://github.com/user-attachments/assets/7a70a5e8-8cd5-4b63-8efd-114dca270a10)

