### PR TITLE
removed 4th chart loading

### DIFF
--- a/components/insightsLoading/insightsLoading.tsx
+++ b/components/insightsLoading/insightsLoading.tsx
@@ -69,7 +69,8 @@ function InsightsLoading() {
           </ContentDiv>
         </TopSection>
       </LoadingFirstContainer>
-      <LoadingSecondContainer>
+      {/* Commented out this code as it may be needed for loading functionality in the future */}
+      {/* <LoadingSecondContainer>
         <HeaderText>Support volume</HeaderText>
         <SecondTopSection>
           <ContentDiv>
@@ -88,7 +89,7 @@ function InsightsLoading() {
             </SecondSpinnerDiv>
           </ContentDiv>
         </SecondTopSection>
-      </LoadingSecondContainer>
+      </LoadingSecondContainer> */}
     </MainContainer>
   );
 }


### PR DESCRIPTION
### What this does
Commented out the 4th chart loading logic since only three charts are currently displayed. This keeps the codebase clean while preserving the logic for potential future use.

### Implementation

- Commented out the code responsible for rendering the 4th chart.
- No functionality is removed—this code can be easily re-enabled when needed.
- Helps reduce unnecessary rendering for now while maintaining flexibility for future updates.

### Testing
<img width="960" alt="image" src="https://github.com/user-attachments/assets/340447af-3e07-42bd-b388-c9b758460670" />

